### PR TITLE
Update dependencies

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -11,7 +11,7 @@ Install these dependencies before you build:
 - [OpenSSL](https://www.openssl.org/) >= 1.0.2
 - [libmysqlclient](https://dev.mysql.com/downloads/connector/c/) (or [libmariadbclient](https://mariadb.org/))
 
-For Debian users, run `sudo apt -y install build-essential cmake libboost-system-dev libssl-dev default-libmariadbclient-dev` to install all the necessary dependencies.
+For Debian users, run `sudo apt -y install build-essential cmake libboost-system-dev libssl-dev default-libmysqlclient-dev` to install all the necessary dependencies.
 
 ## Clone
 


### PR DESCRIPTION
There is no default-libmariadbclient-dev in debian repository, and using libmariadbclient-dev to compile will fail.
However there is default-libmysqlclient-dev and it works.

I'm compiling it in raspberry pi, its system is based on debian.