### PR TITLE
Add dependency

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -8,10 +8,10 @@ Install these dependencies before you build:
 
 - [CMake](https://cmake.org/) >= 3.7.2
 - [Boost](http://www.boost.org/) >= 1.54.0
-- [OpenSSL](https://www.openssl.org/) >= 1.0.2
+- [OpenSSL](https://www.openssl.org/) >= 1.0.2 (Recommand >= 1.1.1)
 - [libmysqlclient](https://dev.mysql.com/downloads/connector/c/)
 
-For Debian users, run `sudo apt -y install build-essential cmake libboost-system-dev libboost-program-options-dev libssl-dev default-libmysqlclient-dev` to install all the necessary dependencies.
+For Debian users, run `sudo apt -y install build-essential cmake libboost-system-dev libboost-program-options-dev libssl-dev default-libmysqlclient-dev python3 curl openssl` to install all the necessary dependencies.
 
 ## Clone
 


### PR DESCRIPTION
Should OpenSSL version changed to 111?
Add necessary `python3 curl openssl` to apt install.