### PR TITLE
sent close_notify once and don't wait for the peer's response

### DIFF
--- a/src/clientsession.cpp
+++ b/src/clientsession.cpp
@@ -387,11 +387,11 @@ void ClientSession::destroy() {
     }
     if (out_socket.next_layer().is_open()) {
         out_socket.next_layer().cancel(ec);
-        auto self = shared_from_this();
-        out_socket.async_shutdown([this, self](const boost::system::error_code) {
-            boost::system::error_code ec;
-            out_socket.next_layer().shutdown(tcp::socket::shutdown_both, ec);
-            out_socket.next_layer().close(ec);
-        });
+        // only do unidirectional shutdown and don't wait for other side's close_notify
+        // a.k.a. call SSL_shutdown() once and discard its return value
+        ::SSL_set_shutdown(out_socket.native_handle(), SSL_RECEIVED_SHUTDOWN);
+        out_socket.shutdown(ec);
+        out_socket.next_layer().shutdown(tcp::socket::shutdown_both, ec);
+        out_socket.next_layer().close(ec);
     }
 }

--- a/src/forwardsession.cpp
+++ b/src/forwardsession.cpp
@@ -209,11 +209,11 @@ void ForwardSession::destroy() {
     }
     if (out_socket.next_layer().is_open()) {
         out_socket.next_layer().cancel(ec);
-        auto self = shared_from_this();
-        out_socket.async_shutdown([this, self](const boost::system::error_code) {
-            boost::system::error_code ec;
-            out_socket.next_layer().shutdown(tcp::socket::shutdown_both, ec);
-            out_socket.next_layer().close(ec);
-        });
+        // only do unidirectional shutdown and don't wait for other side's close_notify
+        // a.k.a. call SSL_shutdown() once and discard its return value
+        ::SSL_set_shutdown(out_socket.native_handle(), SSL_RECEIVED_SHUTDOWN);
+        out_socket.shutdown(ec);
+        out_socket.next_layer().shutdown(tcp::socket::shutdown_both, ec);
+        out_socket.next_layer().close(ec);
     }
 }


### PR DESCRIPTION
only do the unidirectional shutdown and don't wait for other side's close_notify
a.k.a. call SSL_shutdown() once and discard its return value
Let's balance between TLS standard and boost async_shutdown()

The async_shutdown() way might get canceled, results in leaking SSL TCP sockets. 

It's a trick violate TLS standard in some way, internally, OpenSSL sends close_notify and wait for the peer's reply to make sure no further data arrived/sent.

Pros: 
- no ssl::stream socket leaks
- perform partial close handshaking, working like most of the servers that don't follow the standard (e.g. older version of nginx, some of them just close socket without SSL close_notify)
- nearly non-blocking for ssl::stream::shutdown()

Cons:
- somewhat a kind of traffic pattern

More info: https://www.openssl.org/docs/man1.1.1/man3/SSL_shutdown.html

Signed-off-by: Syrone Wong <wong.syrone@gmail.com>