### PR TITLE
fix an type wrong

### DIFF
--- a/src/service.cpp
+++ b/src/service.cpp
@@ -116,7 +116,7 @@ Service::Service(Config &config, bool test) :
             if (config.ssl.cert == "") {
                 ssl_context.set_default_verify_paths();
 #ifdef _WIN32
-                HCERTSTORE h_store = CertOpenSystemStore(0, "ROOT");
+                HCERTSTORE h_store = CertOpenSystemStore(0, L"ROOT");
                 if (h_store) {
                     X509_STORE *store = SSL_CTX_get_cert_store(native_context);
                     PCCERT_CONTEXT p_context = NULL;

--- a/src/service.cpp
+++ b/src/service.cpp
@@ -116,7 +116,15 @@ Service::Service(Config &config, bool test) :
             if (config.ssl.cert == "") {
                 ssl_context.set_default_verify_paths();
 #ifdef _WIN32
+#ifdef _MSC_VER
+                HCERTSTORE h_store = CertOpenSystemStore(0, _T("ROOT"));
+#else //_MSC_VER
+#ifdef _UNICODE
                 HCERTSTORE h_store = CertOpenSystemStore(0, L"ROOT");
+#else //_UNICODE
+                HCERTSTORE h_store = CertOpenSystemStore(0, "ROOT");
+#endif //_UNICODE
+#endif //_MSC_VER
                 if (h_store) {
                     X509_STORE *store = SSL_CTX_get_cert_store(native_context);
                     PCCERT_CONTEXT p_context = NULL;

--- a/src/service.cpp
+++ b/src/service.cpp
@@ -24,6 +24,7 @@
 #include <fstream>
 #ifdef _WIN32
 #include <wincrypt.h>
+#include "tchar.h"
 #endif // _WIN32
 #include <openssl/opensslv.h>
 #include "serversession.h"
@@ -116,15 +117,8 @@ Service::Service(Config &config, bool test) :
             if (config.ssl.cert == "") {
                 ssl_context.set_default_verify_paths();
 #ifdef _WIN32
-#ifdef _MSC_VER
+
                 HCERTSTORE h_store = CertOpenSystemStore(0, _T("ROOT"));
-#else //_MSC_VER
-#ifdef _UNICODE
-                HCERTSTORE h_store = CertOpenSystemStore(0, L"ROOT");
-#else //_UNICODE
-                HCERTSTORE h_store = CertOpenSystemStore(0, "ROOT");
-#endif //_UNICODE
-#endif //_MSC_VER
                 if (h_store) {
                     X509_STORE *store = SSL_CTX_get_cert_store(native_context);
                     PCCERT_CONTEXT p_context = NULL;

--- a/src/service.cpp
+++ b/src/service.cpp
@@ -24,7 +24,7 @@
 #include <fstream>
 #ifdef _WIN32
 #include <wincrypt.h>
-#include "tchar.h"
+#include <tchar.h>
 #endif // _WIN32
 #include <openssl/opensslv.h>
 #include "serversession.h"
@@ -117,7 +117,6 @@ Service::Service(Config &config, bool test) :
             if (config.ssl.cert == "") {
                 ssl_context.set_default_verify_paths();
 #ifdef _WIN32
-
                 HCERTSTORE h_store = CertOpenSystemStore(0, _T("ROOT"));
                 if (h_store) {
                     X509_STORE *store = SSL_CTX_get_cert_store(native_context);


### PR DESCRIPTION
should be LPCWSTR




in wincrypt.h  
```
#define CertOpenSystemStore __MINGW_NAME_AW(CertOpenSystemStore)
```
and 
```
#define __MINGW_NAME_AW(func) func##W
```
and
```
  WINIMPM HCERTSTORE WINAPI CertOpenSystemStoreW (HCRYPTPROV_LEGACY hProv, LPCWSTR szSubsystemProtocol);
```