### PR TITLE
do not use deprecated resolver overload for Boost >= 1.66.0

### DIFF
--- a/src/clientsession.cpp
+++ b/src/clientsession.cpp
@@ -220,11 +220,24 @@ void ClientSession::in_sent() {
             } else {
                 first_packet_recv = true;
             }
+#if BOOST_VERSION >= 106600
+            std::string resolv_host = config.remote_addr;
+            std::string resolv_service = std::to_string(config.remote_port);
+#else
             tcp::resolver::query query(config.remote_addr, to_string(config.remote_port));
+#endif
             auto self = shared_from_this();
+#if BOOST_VERSION >= 106600
+            resolver.async_resolve(resolv_host, resolv_service, [this, self, resolv_host](const boost::system::error_code error, tcp::resolver::iterator iterator) {
+#else
             resolver.async_resolve(query, [this, self](const boost::system::error_code error, tcp::resolver::iterator iterator) {
+#endif
                 if (error) {
+#if BOOST_VERSION >= 106600
+                    Log::log_with_endpoint(in_endpoint, "cannot resolve remote server hostname " + resolv_host + ": " + error.message(), Log::ERROR);
+#else
                     Log::log_with_endpoint(in_endpoint, "cannot resolve remote server hostname " + config.remote_addr + ": " + error.message(), Log::ERROR);
+#endif
                     destroy();
                     return;
                 }

--- a/src/forwardsession.cpp
+++ b/src/forwardsession.cpp
@@ -60,11 +60,24 @@ void ForwardSession::start() {
         first_packet_recv = true;
     }
     Log::log_with_endpoint(in_endpoint, "forwarding to " + config.target_addr + ':' + to_string(config.target_port) + " via " + config.remote_addr + ':' + to_string(config.remote_port), Log::INFO);
+#if BOOST_VERSION >= 106600
+    std::string resolv_host = config.remote_addr;
+    std::string resolv_service = std::to_string(config.remote_port);
+#else
     tcp::resolver::query query(config.remote_addr, to_string(config.remote_port));
+#endif
     auto self = shared_from_this();
+#if BOOST_VERSION >= 106600
+    resolver.async_resolve(resolv_host, resolv_service, [this, self, resolv_host](const boost::system::error_code error, tcp::resolver::iterator iterator) {
+#else
     resolver.async_resolve(query, [this, self](const boost::system::error_code error, tcp::resolver::iterator iterator) {
+#endif
         if (error) {
+#if BOOST_VERSION >= 106600
+            Log::log_with_endpoint(in_endpoint, "cannot resolve remote server hostname " + resolv_host + ": " + error.message(), Log::ERROR);
+#else
             Log::log_with_endpoint(in_endpoint, "cannot resolve remote server hostname " + config.remote_addr + ": " + error.message(), Log::ERROR);
+#endif
             destroy();
             return;
         }

--- a/src/service.cpp
+++ b/src/service.cpp
@@ -44,7 +44,11 @@ Service::Service(Config &config, bool test) :
     udp_socket(io_service) {
     if (!test) {
         tcp::resolver resolver(io_service);
+#if BOOST_VERSION >= 106600
+        tcp::endpoint listen_endpoint = *resolver.resolve(config.local_addr, to_string(config.local_port));
+#else
         tcp::endpoint listen_endpoint = *resolver.resolve(tcp::resolver::query(config.local_addr, to_string(config.local_port)));
+#endif
         socket_acceptor.open(listen_endpoint.protocol());
         socket_acceptor.set_option(tcp::acceptor::reuse_address(true));
         socket_acceptor.bind(listen_endpoint);

--- a/src/service.h
+++ b/src/service.h
@@ -21,6 +21,7 @@
 #define _SERVICE_H_
 
 #include <list>
+#include <boost/version.hpp>
 #include <boost/asio/io_service.hpp>
 #include <boost/asio/ssl.hpp>
 #include <boost/asio/ip/udp.hpp>

--- a/src/session.h
+++ b/src/session.h
@@ -22,6 +22,7 @@
 
 #include <ctime>
 #include <memory>
+#include <boost/version.hpp>
 #include <boost/asio/io_service.hpp>
 #include <boost/asio/ip/udp.hpp>
 #include "config.h"


### PR DESCRIPTION
Signed-off-by: Syrone Wong <wong.syrone@gmail.com>