### PR TITLE
1. enable read keychain on mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,10 +73,10 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
     endif()
 endif()
 
-if (APPLE)
-	find_library(CoreFoundation CoreFoundation)
+if(APPLE)
+    find_library(CoreFoundation CoreFoundation)
     find_library(Security Security)
-	target_link_libraries(trojan ${CoreFoundation} ${Security})
+    target_link_libraries(trojan ${CoreFoundation} ${Security})
 endif()
 
 if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,12 @@ if(CMAKE_SYSTEM_NAME STREQUAL Linux)
     endif()
 endif()
 
+if (APPLE)
+	find_library(CoreFoundation CoreFoundation)
+    find_library(Security Security)
+	target_link_libraries(trojan ${CoreFoundation} ${Security})
+endif()
+
 if(WIN32)
     target_link_libraries(trojan wsock32 ws2_32 crypt32)
 else()

--- a/src/core/service.cpp
+++ b/src/core/service.cpp
@@ -191,7 +191,7 @@ Service::Service(Config &config, bool test) :
                     CFRelease (pSecKeychainSearch);
                     CFRelease (pSecKeychain);
                 }
-#endif
+#endif // __MACH__
             } else {
                 ssl_context.load_verify_file(config.ssl.cert);
             }


### PR DESCRIPTION
enable read keychain from key store on mac to make ssl:{verify:true} option work on mac