### PR TITLE
CMakeLists: Fix build with Boost 1.72.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ find_package(Threads REQUIRED)
 target_link_libraries(trojan ${CMAKE_THREAD_LIBS_INIT})
 
 find_package(Boost 1.66.0 REQUIRED COMPONENTS system program_options)
+add_definitions(-DBOOST_ERROR_CODE_HEADER_ONLY)
 include_directories(${Boost_INCLUDE_DIR})
 target_link_libraries(trojan ${Boost_LIBRARIES})
 if(MSVC)


### PR DESCRIPTION
log.cpp:(.text+0x13f6)：对‘boost::system::system_category()’未定义的引用
service.cpp:(.text+0x433)：对‘boost::system::system_category()’未定义的引用