### PR TITLE
ssl.alpn_port_override (Fixes #171 and #226)

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -174,7 +174,7 @@ The NAT config is for transparent proxy. You'll need to [setup iptables rules](h
         "alpn": [
             "http/1.1"
         ],
-        "alpn_port_override" : {
+        "alpn_port_override": {
             "h2": 81
         },
         "reuse_session": true,
@@ -219,7 +219,7 @@ The NAT config is for transparent proxy. You'll need to [setup iptables rules](h
     - `cipher_tls13`: a cipher list for TLS 1.3 to use
     - `prefer_server_cipher`: whether to prefer server cipher list in a connection
     - `alpn`: a list of `ALPN` protocols to reply
-    - alpn_port_override: overrides the remote port to the specified value if an ALPN is matched. Useful for running nginx http1.1 and http2 on different ports (#226).
+    - `alpn_port_override`: overrides the remote port to the specified value if an `ALPN` is matched. Useful for running NGINX with HTTP/1.1 and HTTP/2 Cleartext on different ports.
     - `reuse_session`: whether to reuse `SSL` session
     - `session_ticket`: whether to use session tickets for session resumption
     - `session_timeout`: if `reuse_session` is set to `true`, specify `SSL` session timeout

--- a/docs/config.md
+++ b/docs/config.md
@@ -174,6 +174,9 @@ The NAT config is for transparent proxy. You'll need to [setup iptables rules](h
         "alpn": [
             "http/1.1"
         ],
+        "alpn_port_override" : {
+            "h2": 81
+        },
         "reuse_session": true,
         "session_ticket": false,
         "session_timeout": 600,
@@ -216,6 +219,7 @@ The NAT config is for transparent proxy. You'll need to [setup iptables rules](h
     - `cipher_tls13`: a cipher list for TLS 1.3 to use
     - `prefer_server_cipher`: whether to prefer server cipher list in a connection
     - `alpn`: a list of `ALPN` protocols to reply
+    - alpn_port_override: overrides the remote port to the specified value if an ALPN is matched. Useful for running nginx http1.1 and http2 on different ports (#226).
     - `reuse_session`: whether to reuse `SSL` session
     - `session_ticket`: whether to use session tickets for session resumption
     - `session_timeout`: if `reuse_session` is set to `true`, specify `SSL` session timeout

--- a/examples/server.json-example
+++ b/examples/server.json-example
@@ -19,7 +19,7 @@
         "alpn": [
             "http/1.1"
         ],
-        "alpn_port_override" : {
+        "alpn_port_override": {
             "h2": 81
         },
         "reuse_session": true,

--- a/examples/server.json-example
+++ b/examples/server.json-example
@@ -19,6 +19,9 @@
         "alpn": [
             "http/1.1"
         ],
+        "alpn_port_override" : {
+            "h2": 81
+        },
         "reuse_session": true,
         "session_ticket": false,
         "session_timeout": 600,

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -42,6 +42,7 @@ public:
     std::map<std::string, std::string> password;
     int udp_timeout;
     Log::Level log_level;
+    std::map<std::string, uint16_t> alpn_port;
     class SSLConfig {
     public:
         bool verify;

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -42,7 +42,6 @@ public:
     std::map<std::string, std::string> password;
     int udp_timeout;
     Log::Level log_level;
-    std::map<std::string, uint16_t> alpn_port;
     class SSLConfig {
     public:
         bool verify;
@@ -55,6 +54,7 @@ public:
         bool prefer_server_cipher;
         std::string sni;
         std::string alpn;
+        std::map<std::string, uint16_t> alpn_port_override;
         bool reuse_session;
         bool session_ticket;
         long session_timeout;

--- a/src/session/serversession.h
+++ b/src/session/serversession.h
@@ -38,6 +38,7 @@ private:
     Authenticator *auth;
     std::string auth_password;
     const std::string &plain_http_response;
+    uint16_t remote_port;
     void destroy();
     void in_async_read();
     void in_async_write(const std::string &data);

--- a/src/session/serversession.h
+++ b/src/session/serversession.h
@@ -38,7 +38,6 @@ private:
     Authenticator *auth;
     std::string auth_password;
     const std::string &plain_http_response;
-    uint16_t remote_port;
     void destroy();
     void in_async_read();
     void in_async_write(const std::string &data);

--- a/tests/LinuxSmokeTest/server.json
+++ b/tests/LinuxSmokeTest/server.json
@@ -14,6 +14,7 @@
         "cipher_tls13": "",
         "prefer_server_cipher": true,
         "alpn": [],
+        "alpn_port_override": {},
         "reuse_session": false,
         "session_ticket": false,
         "session_timeout": 600,


### PR DESCRIPTION
Had some spare time during the weekends and thought I would try to implement the solution I mentioned in #226.

Not sure how to add tests though since `http.server` in Python does not seem to support h2c :/