### PR TITLE
Fix clang-tidy warnings

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -39,7 +39,7 @@ stages:
         set -euo pipefail
         curl -LO https://slproweb.com/download/Win64OpenSSL-1_1_1g.exe
         powershell ".\\Win64OpenSSL-1_1_1g.exe /silent /sp- /suppressmsgboxes /DIR='C:\\Program Files\\OpenSSL-Win64'"
-        cmake -DBoost_USE_STATIC_LIBS=ON -DOPENSSL_ROOT_DIR='C:/Program Files/OpenSSL-Win64' -DOPENSSL_USE_STATIC_LIBS=ON -DENABLE_MYSQL=OFF .
+        cmake -DBoost_INCLUDE_DIR="${BOOST_ROOT_1_72_0}/include" -DBoost_USE_STATIC_LIBS=ON -DOPENSSL_ROOT_DIR='C:/Program Files/OpenSSL-Win64' -DOPENSSL_USE_STATIC_LIBS=ON -DENABLE_MYSQL=OFF .
         cmake --build . --config Release
     - publish: $(System.DefaultWorkingDirectory)/Release/trojan.exe
       artifact: WindowsBinary

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,8 +37,8 @@ stages:
     steps:
     - bash: |
         set -euo pipefail
-        curl -LO https://slproweb.com/download/Win64OpenSSL-1_1_1f.exe
-        powershell ".\\Win64OpenSSL-1_1_1f.exe /silent /sp- /suppressmsgboxes /DIR='C:\\Program Files\\OpenSSL-Win64'"
+        curl -LO https://slproweb.com/download/Win64OpenSSL-1_1_1g.exe
+        powershell ".\\Win64OpenSSL-1_1_1g.exe /silent /sp- /suppressmsgboxes /DIR='C:\\Program Files\\OpenSSL-Win64'"
         cmake -DBoost_USE_STATIC_LIBS=ON -DOPENSSL_ROOT_DIR='C:/Program Files/OpenSSL-Win64' -DOPENSSL_USE_STATIC_LIBS=ON -DENABLE_MYSQL=OFF .
         cmake --build . --config Release
     - publish: $(System.DefaultWorkingDirectory)/Release/trojan.exe

--- a/src/core/authenticator.cpp
+++ b/src/core/authenticator.cpp
@@ -27,17 +27,17 @@ using namespace std;
 Authenticator::Authenticator(const Config &config) {
     mysql_init(&con);
     Log::log_with_date_time("connecting to MySQL server " + config.mysql.server_addr + ':' + to_string(config.mysql.server_port), Log::INFO);
-    if (config.mysql.cafile != "") {
-        mysql_ssl_set(&con, NULL, NULL, config.mysql.cafile.c_str(), NULL, NULL);
+    if (!config.mysql.cafile.empty()) {
+        mysql_ssl_set(&con, nullptr, nullptr, config.mysql.cafile.c_str(), nullptr, nullptr);
     }
     if (mysql_real_connect(&con, config.mysql.server_addr.c_str(),
                                  config.mysql.username.c_str(),
                                  config.mysql.password.c_str(),
                                  config.mysql.database.c_str(),
-                                 config.mysql.server_port, NULL, 0) == NULL) {
+                                 config.mysql.server_port, nullptr, 0) == nullptr) {
         throw runtime_error(mysql_error(&con));
     }
-    bool reconnect = 1;
+    bool reconnect = true;
     mysql_options(&con, MYSQL_OPT_RECONNECT, &reconnect);
     Log::log_with_date_time("connected to MySQL server", Log::INFO);
 }
@@ -51,12 +51,12 @@ bool Authenticator::auth(const string &password) {
         return false;
     }
     MYSQL_RES *res = mysql_store_result(&con);
-    if (res == NULL) {
+    if (res == nullptr) {
         Log::log_with_date_time(mysql_error(&con), Log::ERROR);
         return false;
     }
     MYSQL_ROW row = mysql_fetch_row(res);
-    if (row == NULL) {
+    if (row == nullptr) {
         mysql_free_result(res);
         return false;
     }

--- a/src/core/authenticator.h
+++ b/src/core/authenticator.h
@@ -28,14 +28,14 @@
 class Authenticator {
 private:
 #ifdef ENABLE_MYSQL
-    MYSQL con;
+    MYSQL con{};
 #endif // ENABLE_MYSQL
     enum {
         PASSWORD_LENGTH=56
     };
-    bool is_valid_password(const std::string &password);
+    static bool is_valid_password(const std::string &password);
 public:
-    Authenticator(const Config &config);
+    explicit Authenticator(const Config &config);
     bool auth(const std::string &password);
     void record(const std::string &password, uint64_t download, uint64_t upload);
     ~Authenticator();

--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -113,7 +113,7 @@ void Config::populate(const ptree &tree) {
 
 bool Config::sip003() {
     char *JSON = getenv("SS_PLUGIN_OPTIONS");
-    if (JSON == NULL) {
+    if (JSON == nullptr) {
         return false;
     }
     populate(JSON);
@@ -125,7 +125,6 @@ bool Config::sip003() {
         case CLIENT:
         case NAT:
             throw runtime_error("SIP003 with wrong run_type");
-            break;
         case FORWARD:
             remote_addr = getenv("SS_REMOTE_HOST");
             remote_port = atoi(getenv("SS_REMOTE_PORT"));
@@ -141,10 +140,10 @@ string Config::SHA224(const string &message) {
     char mdString[(EVP_MAX_MD_SIZE << 1) + 1];
     unsigned int digest_len;
     EVP_MD_CTX *ctx;
-    if ((ctx = EVP_MD_CTX_new()) == NULL) {
+    if ((ctx = EVP_MD_CTX_new()) == nullptr) {
         throw runtime_error("could not create hash context");
     }
-    if (!EVP_DigestInit_ex(ctx, EVP_sha224(), NULL)) {
+    if (!EVP_DigestInit_ex(ctx, EVP_sha224(), nullptr)) {
         EVP_MD_CTX_free(ctx);
         throw runtime_error("could not initialize hash context");
     }

--- a/src/core/log.cpp
+++ b/src/core/log.cpp
@@ -32,7 +32,7 @@ using namespace boost::posix_time;
 using namespace boost::asio::ip;
 
 Log::Level Log::level(INFO);
-FILE *Log::keylog(NULL);
+FILE *Log::keylog(nullptr);
 FILE *Log::output_stream(stderr);
 
 void Log::log(const string &message, Level level) {
@@ -49,7 +49,7 @@ void Log::log(const string &message, Level level) {
 
 void Log::log_with_date_time(const string &message, Level level) {
     static const char *level_strings[]= {"ALL", "INFO", "WARN", "ERROR", "FATAL", "OFF"};
-    time_facet *facet = new time_facet("[%Y-%m-%d %H:%M:%S] ");
+    auto *facet = new time_facet("[%Y-%m-%d %H:%M:%S] ");
     ostringstream stream;
     stream.imbue(locale(stream.getloc(), facet));
     stream << second_clock::local_time();
@@ -63,7 +63,7 @@ void Log::log_with_endpoint(const tcp::endpoint &endpoint, const string &message
 
 void Log::redirect(const string &filename) {
     FILE *fp = fopen(filename.c_str(), "a");
-    if (fp == NULL) {
+    if (fp == nullptr) {
         throw runtime_error(filename + ": " + strerror(errno));
     }
     if (output_stream != stderr) {
@@ -74,10 +74,10 @@ void Log::redirect(const string &filename) {
 
 void Log::redirect_keylog(const string &filename) {
     FILE *fp = fopen(filename.c_str(), "a");
-    if (fp == NULL) {
+    if (fp == nullptr) {
         throw runtime_error(filename + ": " + strerror(errno));
     }
-    if (keylog != NULL) {
+    if (keylog != nullptr) {
         fclose(keylog);
     }
     keylog = fp;
@@ -88,8 +88,8 @@ void Log::reset() {
         fclose(output_stream);
         output_stream = stderr;
     }
-    if (keylog != NULL) {
+    if (keylog != nullptr) {
         fclose(keylog);
-        keylog = NULL;
+        keylog = nullptr;
     }
 }

--- a/src/core/service.cpp
+++ b/src/core/service.cpp
@@ -80,7 +80,7 @@ Service::Service(Config &config, bool test) :
     Log::level = config.log_level;
     auto native_context = ssl_context.native_handle();
     ssl_context.set_options(context::default_workarounds | context::no_sslv2 | context::no_sslv3 | context::single_dh_use);
-    if (config.ssl.curves != "") {
+    if (!config.ssl.curves.empty()) {
         SSL_CTX_set1_curves_list(native_context, config.ssl.curves.c_str());
     }
     if (config.run_type == Config::SERVER) {
@@ -92,7 +92,7 @@ Service::Service(Config &config, bool test) :
         if (config.ssl.prefer_server_cipher) {
             SSL_CTX_set_options(native_context, SSL_OP_CIPHER_SERVER_PREFERENCE);
         }
-        if (config.ssl.alpn != "") {
+        if (!config.ssl.alpn.empty()) {
             SSL_CTX_set_alpn_select_cb(native_context, [](SSL*, const unsigned char **out, unsigned char *outlen, const unsigned char *in, unsigned int inlen, void *config) -> int {
                 if (SSL_select_next_proto((unsigned char**)out, outlen, (unsigned char*)(((Config*)config)->ssl.alpn.c_str()), ((Config*)config)->ssl.alpn.length(), in, inlen) != OPENSSL_NPN_NEGOTIATED) {
                     return SSL_TLSEXT_ERR_NOACK;
@@ -109,14 +109,14 @@ Service::Service(Config &config, bool test) :
             SSL_CTX_set_session_cache_mode(native_context, SSL_SESS_CACHE_OFF);
             SSL_CTX_set_options(native_context, SSL_OP_NO_TICKET);
         }
-        if (config.ssl.plain_http_response != "") {
+        if (!config.ssl.plain_http_response.empty()) {
             ifstream ifs(config.ssl.plain_http_response, ios::binary);
             if (!ifs.is_open()) {
                 throw runtime_error(config.ssl.plain_http_response + ": " + strerror(errno));
             }
             plain_http_response = string(istreambuf_iterator<char>(ifs), istreambuf_iterator<char>());
         }
-        if (config.ssl.dhparam == "") {
+        if (config.ssl.dhparam.empty()) {
             ssl_context.use_tmp_dh(boost::asio::const_buffer(SSLDefaults::g_dh2048_sz, SSLDefaults::g_dh2048_sz_size));
         } else {
             ssl_context.use_tmp_dh_file(config.ssl.dhparam);
@@ -129,12 +129,12 @@ Service::Service(Config &config, bool test) :
 #endif // ENABLE_MYSQL
         }
     } else {
-        if (config.ssl.sni == "") {
+        if (config.ssl.sni.empty()) {
             config.ssl.sni = config.remote_addr;
         }
         if (config.ssl.verify) {
             ssl_context.set_verify_mode(verify_peer);
-            if (config.ssl.cert == "") {
+            if (config.ssl.cert.empty()) {
                 ssl_context.set_default_verify_paths();
 #ifdef _WIN32
                 HCERTSTORE h_store = CertOpenSystemStore(0, _T("ROOT"));
@@ -215,7 +215,7 @@ Service::Service(Config &config, bool test) :
         } else {
             ssl_context.set_verify_mode(verify_none);
         }
-        if (config.ssl.alpn != "") {
+        if (!config.ssl.alpn.empty()) {
             SSL_CTX_set_alpn_protos(native_context, (unsigned char*)(config.ssl.alpn.c_str()), config.ssl.alpn.length());
         }
         if (config.ssl.reuse_session) {
@@ -228,10 +228,10 @@ Service::Service(Config &config, bool test) :
             SSL_CTX_set_options(native_context, SSL_OP_NO_TICKET);
         }
     }
-    if (config.ssl.cipher != "") {
+    if (!config.ssl.cipher.empty()) {
         SSL_CTX_set_cipher_list(native_context, config.ssl.cipher.c_str());
     }
-    if (config.ssl.cipher_tls13 != "") {
+    if (!config.ssl.cipher_tls13.empty()) {
 #ifdef ENABLE_TLS13_CIPHERSUITES
         SSL_CTX_set_ciphersuites(native_context, config.ssl.cipher_tls13.c_str());
 #else  // ENABLE_TLS13_CIPHERSUITES

--- a/src/core/service.h
+++ b/src/core/service.h
@@ -40,12 +40,12 @@ private:
     std::string plain_http_response;
     boost::asio::ip::udp::socket udp_socket;
     std::list<std::weak_ptr<UDPForwardSession> > udp_sessions;
-    uint8_t udp_read_buf[MAX_LENGTH];
+    uint8_t udp_read_buf[MAX_LENGTH]{};
     boost::asio::ip::udp::endpoint udp_recv_endpoint;
     void async_accept();
     void udp_async_read();
 public:
-    Service(Config &config, bool test = false);
+    explicit Service(Config &config, bool test = false);
     void run();
     void stop();
     boost::asio::io_context &service();

--- a/src/session/clientsession.cpp
+++ b/src/session/clientsession.cpp
@@ -38,14 +38,14 @@ tcp::socket& ClientSession::accept_socket() {
 
 void ClientSession::start() {
     boost::system::error_code ec;
-    start_time = time(NULL);
+    start_time = time(nullptr);
     in_endpoint = in_socket.remote_endpoint(ec);
     if (ec) {
         destroy();
         return;
     }
     auto ssl = out_socket.native_handle();
-    if (config.ssl.sni != "") {
+    if (!config.ssl.sni.empty()) {
         SSL_set_tlsext_host_name(ssl, config.ssl.sni.c_str());
     }
     if (config.ssl.reuse_session) {
@@ -222,8 +222,8 @@ void ClientSession::in_sent() {
                 udp_async_read();
             }
             auto self = shared_from_this();
-            resolver.async_resolve(config.remote_addr, to_string(config.remote_port), [this, self](const boost::system::error_code error, tcp::resolver::results_type results) {
-                if (error || results.size() == 0) {
+            resolver.async_resolve(config.remote_addr, to_string(config.remote_port), [this, self](const boost::system::error_code error, const tcp::resolver::results_type& results) {
+                if (error || results.empty()) {
                     Log::log_with_endpoint(in_endpoint, "cannot resolve remote server hostname " + config.remote_addr + ": " + error.message(), Log::ERROR);
                     destroy();
                     return;
@@ -383,7 +383,7 @@ void ClientSession::destroy() {
         return;
     }
     status = DESTROY;
-    Log::log_with_endpoint(in_endpoint, "disconnected, " + to_string(recv_len) + " bytes received, " + to_string(sent_len) + " bytes sent, lasted for " + to_string(time(NULL) - start_time) + " seconds", Log::INFO);
+    Log::log_with_endpoint(in_endpoint, "disconnected, " + to_string(recv_len) + " bytes received, " + to_string(sent_len) + " bytes sent, lasted for " + to_string(time(nullptr) - start_time) + " seconds", Log::INFO);
     boost::system::error_code ec;
     resolver.cancel();
     if (in_socket.is_open()) {

--- a/src/session/clientsession.h
+++ b/src/session/clientsession.h
@@ -34,7 +34,7 @@ private:
         INVALID,
         DESTROY
     } status;
-    bool is_udp;
+    bool is_udp{};
     bool first_packet_recv;
     boost::asio::ip::tcp::socket in_socket;
     boost::asio::ssl::stream<boost::asio::ip::tcp::socket>out_socket;
@@ -53,8 +53,8 @@ private:
     void udp_sent();
 public:
     ClientSession(const Config &config, boost::asio::io_context &io_context, boost::asio::ssl::context &ssl_context);
-    boost::asio::ip::tcp::socket& accept_socket();
-    void start();
+    boost::asio::ip::tcp::socket& accept_socket() override;
+    void start() override;
 };
 
 #endif // _CLIENTSESSION_H_

--- a/src/session/forwardsession.cpp
+++ b/src/session/forwardsession.cpp
@@ -37,14 +37,14 @@ tcp::socket& ForwardSession::accept_socket() {
 
 void ForwardSession::start() {
     boost::system::error_code ec;
-    start_time = time(NULL);
+    start_time = time(nullptr);
     in_endpoint = in_socket.remote_endpoint(ec);
     if (ec) {
         destroy();
         return;
     }
     auto ssl = out_socket.native_handle();
-    if (config.ssl.sni != "") {
+    if (!config.ssl.sni.empty()) {
         SSL_set_tlsext_host_name(ssl, config.ssl.sni.c_str());
     }
     if (config.ssl.reuse_session) {
@@ -57,8 +57,8 @@ void ForwardSession::start() {
     in_async_read();
     Log::log_with_endpoint(in_endpoint, "forwarding to " + config.target_addr + ':' + to_string(config.target_port) + " via " + config.remote_addr + ':' + to_string(config.remote_port), Log::INFO);
     auto self = shared_from_this();
-    resolver.async_resolve(config.remote_addr, to_string(config.remote_port), [this, self](const boost::system::error_code error, tcp::resolver::results_type results) {
-        if (error || results.size() == 0) {
+    resolver.async_resolve(config.remote_addr, to_string(config.remote_port), [this, self](const boost::system::error_code error, const tcp::resolver::results_type& results) {
+        if (error || results.empty()) {
             Log::log_with_endpoint(in_endpoint, "cannot resolve remote server hostname " + config.remote_addr + ": " + error.message(), Log::ERROR);
             destroy();
             return;
@@ -201,7 +201,7 @@ void ForwardSession::destroy() {
         return;
     }
     status = DESTROY;
-    Log::log_with_endpoint(in_endpoint, "disconnected, " + to_string(recv_len) + " bytes received, " + to_string(sent_len) + " bytes sent, lasted for " + to_string(time(NULL) - start_time) + " seconds", Log::INFO);
+    Log::log_with_endpoint(in_endpoint, "disconnected, " + to_string(recv_len) + " bytes received, " + to_string(sent_len) + " bytes sent, lasted for " + to_string(time(nullptr) - start_time) + " seconds", Log::INFO);
     boost::system::error_code ec;
     resolver.cancel();
     if (in_socket.is_open()) {

--- a/src/session/forwardsession.h
+++ b/src/session/forwardsession.h
@@ -44,8 +44,8 @@ private:
     void out_sent();
 public:
     ForwardSession(const Config &config, boost::asio::io_context &io_context, boost::asio::ssl::context &ssl_context);
-    boost::asio::ip::tcp::socket& accept_socket();
-    void start();
+    boost::asio::ip::tcp::socket& accept_socket() override;
+    void start() override;
 };
 
 #endif // _FORWARDSESSION_H_

--- a/src/session/natsession.cpp
+++ b/src/session/natsession.cpp
@@ -51,6 +51,7 @@ pair<string, uint16_t> NATSession::get_target_endpoint() {
     int fd = in_socket.native_handle();
     // Taken from https://github.com/shadowsocks/shadowsocks-libev/blob/v3.3.1/src/redir.c.
     sockaddr_storage destaddr;
+    memset(&destaddr, 0, sizeof(sockaddr_storage));
     socklen_t socklen = sizeof(destaddr);
     int error = getsockopt(fd, SOL_IPV6, IP6T_SO_ORIGINAL_DST, &destaddr, &socklen);
     if (error) {
@@ -62,11 +63,11 @@ pair<string, uint16_t> NATSession::get_target_endpoint() {
     char ipstr[INET6_ADDRSTRLEN];
     uint16_t port;
     if (destaddr.ss_family == AF_INET) {
-        sockaddr_in *sa = (sockaddr_in*) &destaddr;
+        auto *sa = (sockaddr_in*) &destaddr;
         inet_ntop(AF_INET, &(sa->sin_addr), ipstr, INET_ADDRSTRLEN);
         port = ntohs(sa->sin_port);
     } else {
-        sockaddr_in6 *sa = (sockaddr_in6*) &destaddr;
+        auto *sa = (sockaddr_in6*) &destaddr;
         inet_ntop(AF_INET6, &(sa->sin6_addr), ipstr, INET6_ADDRSTRLEN);
         port = ntohs(sa->sin6_port);
     }
@@ -78,14 +79,14 @@ pair<string, uint16_t> NATSession::get_target_endpoint() {
 
 void NATSession::start() {
     boost::system::error_code ec;
-    start_time = time(NULL);
+    start_time = time(nullptr);
     in_endpoint = in_socket.remote_endpoint(ec);
     if (ec) {
         destroy();
         return;
     }
     auto ssl = out_socket.native_handle();
-    if (config.ssl.sni != "") {
+    if (!config.ssl.sni.empty()) {
         SSL_set_tlsext_host_name(ssl, config.ssl.sni.c_str());
     }
     if (config.ssl.reuse_session) {
@@ -105,8 +106,8 @@ void NATSession::start() {
     in_async_read();
     Log::log_with_endpoint(in_endpoint, "forwarding to " + target_addr + ':' + to_string(target_port) + " via " + config.remote_addr + ':' + to_string(config.remote_port), Log::INFO);
     auto self = shared_from_this();
-    resolver.async_resolve(config.remote_addr, to_string(config.remote_port), [this, self](const boost::system::error_code error, tcp::resolver::results_type results) {
-        if (error || results.size() == 0) {
+    resolver.async_resolve(config.remote_addr, to_string(config.remote_port), [this, self](const boost::system::error_code error, const tcp::resolver::results_type& results) {
+        if (error || results.empty()) {
             Log::log_with_endpoint(in_endpoint, "cannot resolve remote server hostname " + config.remote_addr + ": " + error.message(), Log::ERROR);
             destroy();
             return;
@@ -249,7 +250,7 @@ void NATSession::destroy() {
         return;
     }
     status = DESTROY;
-    Log::log_with_endpoint(in_endpoint, "disconnected, " + to_string(recv_len) + " bytes received, " + to_string(sent_len) + " bytes sent, lasted for " + to_string(time(NULL) - start_time) + " seconds", Log::INFO);
+    Log::log_with_endpoint(in_endpoint, "disconnected, " + to_string(recv_len) + " bytes received, " + to_string(sent_len) + " bytes sent, lasted for " + to_string(time(nullptr) - start_time) + " seconds", Log::INFO);
     boost::system::error_code ec;
     resolver.cancel();
     if (in_socket.is_open()) {

--- a/src/session/natsession.h
+++ b/src/session/natsession.h
@@ -45,8 +45,8 @@ private:
     std::pair<std::string, uint16_t> get_target_endpoint();
 public:
     NATSession(const Config &config, boost::asio::io_context &io_context, boost::asio::ssl::context &ssl_context);
-    boost::asio::ip::tcp::socket& accept_socket();
-    void start();
+    boost::asio::ip::tcp::socket& accept_socket() override;
+    void start() override;
 };
 
 #endif // _NATSESSION_H_

--- a/src/session/serversession.h
+++ b/src/session/serversession.h
@@ -53,8 +53,8 @@ private:
     void udp_sent();
 public:
     ServerSession(const Config &config, boost::asio::io_context &io_context, boost::asio::ssl::context &ssl_context, Authenticator *auth, const std::string &plain_http_response);
-    boost::asio::ip::tcp::socket& accept_socket();
-    void start();
+    boost::asio::ip::tcp::socket& accept_socket() override;
+    void start() override;
 };
 
 #endif // _SERVERSESSION_H_

--- a/src/session/session.cpp
+++ b/src/session/session.cpp
@@ -26,4 +26,4 @@ Session::Session(const Config &config, boost::asio::io_context &io_context) : co
                                                                               udp_socket(io_context),
                                                                               ssl_shutdown_timer(io_context) {}
 
-Session::~Session() {}
+Session::~Session() = default;

--- a/src/session/session.h
+++ b/src/session/session.h
@@ -34,12 +34,12 @@ protected:
         SSL_SHUTDOWN_TIMEOUT = 30
     };
     const Config &config;
-    uint8_t in_read_buf[MAX_LENGTH];
-    uint8_t out_read_buf[MAX_LENGTH];
-    uint8_t udp_read_buf[MAX_LENGTH];
+    uint8_t in_read_buf[MAX_LENGTH]{};
+    uint8_t out_read_buf[MAX_LENGTH]{};
+    uint8_t udp_read_buf[MAX_LENGTH]{};
     uint64_t recv_len;
     uint64_t sent_len;
-    time_t start_time;
+    time_t start_time{};
     std::string out_write_buf;
     std::string udp_data_buf;
     boost::asio::ip::tcp::resolver resolver;

--- a/src/session/udpforwardsession.cpp
+++ b/src/session/udpforwardsession.cpp
@@ -19,6 +19,7 @@
 
 #include "udpforwardsession.h"
 #include <stdexcept>
+#include <utility>
 #include "ssl/sslsession.h"
 #include "proto/trojanrequest.h"
 #include "proto/udppacket.h"
@@ -26,10 +27,10 @@ using namespace std;
 using namespace boost::asio::ip;
 using namespace boost::asio::ssl;
 
-UDPForwardSession::UDPForwardSession(const Config &config, boost::asio::io_context &io_context, context &ssl_context, const udp::endpoint &endpoint, const UDPWrite &in_write) :
+UDPForwardSession::UDPForwardSession(const Config &config, boost::asio::io_context &io_context, context &ssl_context, const udp::endpoint &endpoint, UDPWrite in_write) :
     Session(config, io_context),
     status(CONNECT),
-    in_write(in_write),
+    in_write(std::move(in_write)),
     out_socket(io_context, ssl_context),
     gc_timer(io_context) {
     udp_recv_endpoint = endpoint;
@@ -42,9 +43,9 @@ tcp::socket& UDPForwardSession::accept_socket() {
 
 void UDPForwardSession::start() {
     timer_async_wait();
-    start_time = time(NULL);
+    start_time = time(nullptr);
     auto ssl = out_socket.native_handle();
-    if (config.ssl.sni != "") {
+    if (!config.ssl.sni.empty()) {
         SSL_set_tlsext_host_name(ssl, config.ssl.sni.c_str());
     }
     if (config.ssl.reuse_session) {
@@ -56,8 +57,8 @@ void UDPForwardSession::start() {
     out_write_buf = TrojanRequest::generate(config.password.cbegin()->first, config.target_addr, config.target_port, false);
     Log::log_with_endpoint(in_endpoint, "forwarding UDP packets to " + config.target_addr + ':' + to_string(config.target_port) + " via " + config.remote_addr + ':' + to_string(config.remote_port), Log::INFO);
     auto self = shared_from_this();
-    resolver.async_resolve(config.remote_addr, to_string(config.remote_port), [this, self](const boost::system::error_code error, tcp::resolver::results_type results) {
-        if (error || results.size() == 0) {
+    resolver.async_resolve(config.remote_addr, to_string(config.remote_port), [this, self](const boost::system::error_code error, const tcp::resolver::results_type& results) {
+        if (error || results.empty()) {
             Log::log_with_endpoint(in_endpoint, "cannot resolve remote server hostname " + config.remote_addr + ": " + error.message(), Log::ERROR);
             destroy();
             return;
@@ -216,7 +217,7 @@ void UDPForwardSession::destroy() {
         return;
     }
     status = DESTROY;
-    Log::log_with_endpoint(in_endpoint, "disconnected, " + to_string(recv_len) + " bytes received, " + to_string(sent_len) + " bytes sent, lasted for " + to_string(time(NULL) - start_time) + " seconds", Log::INFO);
+    Log::log_with_endpoint(in_endpoint, "disconnected, " + to_string(recv_len) + " bytes received, " + to_string(sent_len) + " bytes sent, lasted for " + to_string(time(nullptr) - start_time) + " seconds", Log::INFO);
     resolver.cancel();
     gc_timer.cancel();
     if (out_socket.next_layer().is_open()) {

--- a/src/session/udpforwardsession.h
+++ b/src/session/udpforwardsession.h
@@ -45,9 +45,9 @@ private:
     void out_sent();
     void timer_async_wait();
 public:
-    UDPForwardSession(const Config &config, boost::asio::io_context &io_context, boost::asio::ssl::context &ssl_context, const boost::asio::ip::udp::endpoint &endpoint, const UDPWrite &in_write);
-    boost::asio::ip::tcp::socket& accept_socket();
-    void start();
+    UDPForwardSession(const Config &config, boost::asio::io_context &io_context, boost::asio::ssl::context &ssl_context, const boost::asio::ip::udp::endpoint &endpoint, UDPWrite in_write);
+    boost::asio::ip::tcp::socket& accept_socket() override;
+    void start() override;
     bool process(const boost::asio::ip::udp::endpoint &endpoint, const std::string &data);
 };
 

--- a/src/ssl/sslsession.cpp
+++ b/src/ssl/sslsession.cpp
@@ -32,8 +32,8 @@ void SSLSession::remove_session_cb(SSL_CTX*, SSL_SESSION *session) {
 }
 
 SSL_SESSION *SSLSession::get_session() {
-    if (sessions.size() == 0) {
-        return NULL;
+    if (sessions.empty()) {
+        return nullptr;
     }
     return sessions.front();
 }


### PR DESCRIPTION
Fix clang-tidy warnings

1. replace `NULL` with `nullptr`

2. use `empty()` to check if the container has no elements

3. make member function `static` when it doesn't depend on any class members

4. use `explicit` when the constructor has only one argument

5. use const reference to avoid unnecessary copy

6. use `override` to annotate the virtual function in Derive class override the Base's

7. use `memset` to initialize the struct before using

8. other trivial refinements

Cheers!
