### PR TITLE
Avoid a race condition that makes the test to fail on parallel running

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,4 +126,5 @@ else()
              COMMAND bash ${CMAKE_SOURCE_DIR}/tests/LinuxSmokeTest/basic.sh ${CMAKE_BINARY_DIR}/trojan)
     add_test(NAME LinuxSmokeTest-fake-client
              COMMAND bash ${CMAKE_SOURCE_DIR}/tests/LinuxSmokeTest/fake-client.sh ${CMAKE_BINARY_DIR}/trojan)
+    SET_TESTS_PROPERTIES(LinuxSmokeTest-fake-client PROPERTIES DEPENDS "LinuxSmokeTest-basic")
 endif()


### PR DESCRIPTION
On condition that you invoke tests via `ctest -j2`, the two tests:
 - LinuxSmokeTest-fake-client
 - LinuxSmokeTest-basic

will be will be started at same time, parallelly.

But the two tests shares ports (a.k.a. `10081`, `10080`, `10443`, `11080`), So while one is running, parts of another one will fail to start (in silent) with an `Address already in use` error. Either of the two test will fail or just stuck at the wait_port phase.

There is two ways to fix this
 - Change default test ports
 - Avoid parallel running by a dummy dependences

Since those tests are not time consuming, I think the later solution will be better. If you think former one is better, be free to close this PR and change ports (or ask me to do so). 

For the build error caused by this, you can refer to a [succeed test][s] and a [failed][f] one after a [Fedora 33 Change][change] that force all cmake build flags be passed with a parallel flag.

[s]: https://kojipkgs.fedoraproject.org//work/tasks/2043/46562043/build.log
[f]: https://kojipkgs.fedoraproject.org//work/tasks/2048/46562048/build.log
[change]: https://fedoraproject.org/wiki/Changes/CMake_to_do_out-of-source_builds