### PR TITLE
Add -d option to fork into background as a daemon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,12 @@ else()
         install(FILES ${CMAKE_BINARY_DIR}/trojan.service ${CMAKE_BINARY_DIR}/trojan@.service DESTINATION ${SYSTEMD_SERVICE_PATH})
     endif()
 
+    include(CheckSymbolExists)
+    check_symbol_exists(daemon "stdlib.h" HAVE_DAEMON)
+    if(HAVE_DAEMON)
+        add_definitions(-DHAVE_DAEMON)
+    endif()
+
     enable_testing()
     add_test(NAME LinuxSmokeTest-basic
              COMMAND bash ${CMAKE_SOURCE_DIR}/tests/LinuxSmokeTest/basic.sh ${CMAKE_BINARY_DIR}/trojan)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ else()
     endif()
 
     include(CheckSymbolExists)
-    check_symbol_exists(daemon "stdlib.h" HAVE_DAEMON)
+    check_symbol_exists(daemon "stdlib.h;unistd.h" HAVE_DAEMON)
     if(HAVE_DAEMON)
         add_definitions(-DHAVE_DAEMON)
     endif()

--- a/docs/trojan.1
+++ b/docs/trojan.1
@@ -14,6 +14,9 @@ and start either a proxy client or a proxy server.
 .BR \-c, " " \-\-config=\fICONFIG\fR
 Set the config file to be loaded. Default is \fI/etc/trojan/config.json\fR.
 .TP
+.BR \-d, " " \-\-daemon
+Detach from the terminal and run in the background as a daemon.
+.TP
 .BR \-h, " " \-\-help
 Print help message.
 .TP

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -4,6 +4,7 @@
 usage: ./trojan [-htv] [-l LOG] [-k KEYLOG] [[-c] CONFIG]
 options:
   -c [ --config ] CONFIG specify config file
+  -d [ --daemon ]        fork into background
   -h [ --help ]          print help message
   -k [ --keylog ] KEYLOG specify keylog file location (OpenSSL >= 1.1.1)
   -l [ --log ] LOG       specify log file location

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,6 +26,9 @@
 #ifdef ENABLE_MYSQL
 #include <mysql.h>
 #endif // ENABLE_MYSQL
+#ifdef HAVE_DAEMON
+#include <unistd.h>
+#endif // HAVE_DAEMON
 #include "core/service.h"
 #include "core/version.h"
 using namespace std;


### PR DESCRIPTION
This is useful on systems like OpenBSD which don't have a service
manager like systemd. The daemon() call is available on Linux and
OpenBSD, not sure about other systems.