### PR TITLE
Using multi-stage build to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,20 @@
-FROM alpine:3.11
-
-COPY . trojan
-RUN apk add --no-cache --virtual .build-deps \
+FROM alpine:3.15 AS builder
+COPY . /trojan
+RUN apk add --no-cache \
+        boost-dev \
         build-base \
         cmake \
-        boost-dev \
-        openssl-dev \
         mariadb-connector-c-dev \
-    && (cd trojan && cmake . && make -j $(nproc) && strip -s trojan \
-    && mv trojan /usr/local/bin) \
-    && rm -rf trojan \
-    && apk del .build-deps \
-    && apk add --no-cache --virtual .trojan-rundeps \
-        libstdc++ \
-        boost-system \
+        openssl-dev \
+    && (cd /trojan && cmake . && make -j $(nproc) && strip -s trojan)
+
+FROM alpine:3.15
+RUN apk add --no-cache \
         boost-program_options \
+        boost-system \
+        libstdc++ \
         mariadb-connector-c
+COPY --from=builder /trojan/trojan /usr/local/bin/trojan
 
 WORKDIR /config
-CMD ["trojan", "config.json"]
+ENTRYPOINT ["/usr/local/bin/trojan", "/config/config.json"]


### PR DESCRIPTION
I've been working with docker/k8s recently and was looking for ways to reduce image size. I improved the trojan's Dockerfile while I was doing some experiments. This change reduces the image size from 11.1 MiB to 9.67 MiB.

References:
- https://docs.docker.com/develop/develop-images/multistage-build/
- https://www.youtube.com/watch?v=wGz_cbtCiEA