### PR TITLE
perf: improve Trojan header splicing perf

### DIFF
--- a/src/session/clientsession.cpp
+++ b/src/session/clientsession.cpp
@@ -162,7 +162,10 @@ void ClientSession::in_recv(const string &data) {
                 destroy();
                 return;
             }
-            out_write_buf = config.password.cbegin()->first + "\r\n" + data[1] + data.substr(3) + "\r\n";
+            out_write_buf = string().append(config.password.cbegin()->first)
+                    .append("\r\n").append(1, data[1])
+                    .append(data.substr(3))
+                    .append("\r\n");
             TrojanRequest req;
             if (req.parse(out_write_buf) == -1) {
                 Log::log_with_endpoint(in_endpoint, "unsupported command", Log::ERROR);


### PR DESCRIPTION
Use overloaded `+` **operator** to splice string would cause a new string to be constructed, and more unnecessary string will be constructed when splicing string consecutively. `append()` just simply append parameter to the end of initial string if there is suffient capacity of string, rather than contructing one.

Considering that one TCP/UDP connection would create one Trojan header, I think this small change can slightly impove performance when creating lots of connections.